### PR TITLE
Fix statsd success return code

### DIFF
--- a/src/modules/statsd/statsd.c
+++ b/src/modules/statsd/statsd.c
@@ -239,7 +239,7 @@ static int convert_result(bool result)
 		return -1;
 	}
 
-	return 0;
+	return 1;
 }
 
 char *get_milliseconds(char *dst)


### PR DESCRIPTION
By mistake we return 0, instead of 1 for successful case.
